### PR TITLE
Minor phrasing tweaks

### DIFF
--- a/_maps/tgstation2.dm
+++ b/_maps/tgstation2.dm
@@ -24,7 +24,7 @@ z7 = empty space
         //#include "map_files\generic\z7.dmm"
 
         #define MAP_FILE "tgstation.2.1.3.dmm"
-        #define MAP_NAME "Box Station"
+        #define MAP_NAME "Vault 113: Wasteland"
 
         #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = SELFLOOPING, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -71,7 +71,7 @@
 
 ///post_setup()
 ///Everyone should now be on the station and have their normal gear.  This is the place to give the special roles extra things
-/datum/game_mode/proc/post_setup(report=1)
+/datum/game_mode/proc/post_setup(report=0) //toggle to 1 to have the game auto adjust the alert level.
 	spawn (ROUNDSTART_LOGOUT_REPORT_TIME)
 		display_roundstart_logout_report()
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -136,7 +136,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/Stat()
 	..()
 	if(statpanel("Status"))
-		stat(null, "Station Time: [worldtime2text()]")
+		stat(null, "World Time: [worldtime2text()]")
 		if(ticker)
 			if(ticker.mode)
 				for(var/datum/gang/G in ticker.mode.gangs)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -241,7 +241,7 @@ var/list/ai_list = list()
 
 		if(!stat)
 			stat(null, text("System integrity: [(health+100)/2]%"))
-			stat(null, "Station Time: [worldtime2text()]")
+			stat(null, "World Time: [worldtime2text()]")
 			stat(null, text("Connected cyborgs: [connected_robots.len]"))
 			var/area/borg_area
 			for(var/mob/living/silicon/robot/R in connected_robots)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -335,7 +335,7 @@
 		else
 			stat(null, text("No Cell Inserted!"))
 
-		stat("Station Time:", worldtime2text())
+		stat("World Time:", worldtime2text())
 		if(module)
 			internal = locate(/obj/item/weapon/tank/jetpack) in module.modules
 			if(internal)


### PR DESCRIPTION
Adjusted the use of "station time" to "world time" in a couple of places, and changed the map name from "Box Station" to "Vault 113: Wasteland". 

I'm not sure if you want these, they're so tiny you might just want to do it yourself. I put this together to see if I have everything working properly and can make pull requests should I have something more useful in the future. 