### PR TITLE
Manifest Adjustment

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -103,6 +103,7 @@
 	<tr class='head'><th>Name</th><th>Rank</th></tr>
 	"}
 	var/even = 0
+	var/banner = 0
 	// sort mobs
 	for(var/datum/data/record/t in data_core.general)
 		var/name = t.fields["name"]
@@ -111,27 +112,35 @@
 		if(rank in command_positions)
 			heads[name] = rank
 			department = 1
+			banner = 1
 		if(rank in security_positions)
 			sec[name] = rank
 			department = 1
+			banner = 1
 		if(rank in engineering_positions)
 			eng[name] = rank
 			department = 1
+			banner = 1
 		if(rank in medical_positions)
 			med[name] = rank
 			department = 1
+			banner = 1
 		if(rank in science_positions)
 			sci[name] = rank
 			department = 1
+			banner = 1
 		if(rank in supply_positions)
 			sup[name] = rank
 			department = 1
+			banner = 1
 		if(rank in civilian_positions)
 			civ[name] = rank
 			department = 1
+			banner = 1
 		if(rank in nonhuman_positions)
 			bot[name] = rank
 			department = 1
+			banner = 1
 		if(rank in legion_positions)
 			leg[name] = rank
 			department = 1
@@ -140,9 +149,9 @@
 			department = 1
 		if(!department && !(name in heads))
 			misc[name] = rank
-	if(heads.len > 0)
-		//Testing colspan 2, adjust as needed.
+	if(banner)
 		dat += "<tr><th colspan=4><b>~Vault Personnel~</b></th></tr>"
+	if(heads.len > 0)
 		dat += "<tr><th colspan=3>Heads</th></tr>"
 		for(var/name in heads)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[heads[name]]</td></tr>"

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -87,6 +87,8 @@
 	var/list/sup = list()
 	var/list/civ = list()
 	var/list/bot = list()
+	var/list/leg = list() //ADDED LEGION
+	var/list/wast = list() //ADDED WASTELAND
 	var/list/misc = list()
 	var/dat = {"
 	<head><style>
@@ -130,9 +132,17 @@
 		if(rank in nonhuman_positions)
 			bot[name] = rank
 			department = 1
+		if(rank in legion_positions)
+			leg[name] = rank
+			department = 1
+		if(rank in wasteland_positions)
+			wast[name] = rank
+			department = 1
 		if(!department && !(name in heads))
 			misc[name] = rank
 	if(heads.len > 0)
+		//Testing colspan 2, adjust as needed.
+		dat += "<tr><th colspan=4><b>~Vault Personnel~</b></th></tr>"
 		dat += "<tr><th colspan=3>Heads</th></tr>"
 		for(var/name in heads)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[heads[name]]</td></tr>"
@@ -179,6 +189,17 @@
 		for(var/name in misc)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[misc[name]]</td></tr>"
 			even = !even
+	if(leg.len > 0) //Adds legion to the manifest
+		dat += "<tr><th colspan=4><b>~Legion~</b></th></tr>"
+		for(var/name in leg)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[leg[name]]</td></tr>"
+			even = !even
+	if(wast.len > 0) //Adds wasteland roles to the manifest
+		dat += "<tr><th colspan=4><b>~Wasteland~</b></th></tr>"
+		for(var/name in wast)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[wast[name]]</td></tr>"
+			even = !even
+	// misc guys will go in the vault.
 
 	dat += "</table>"
 	dat = replacetext(dat, "\n", "")

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -1,48 +1,55 @@
-
-var/const/ENGSEC			=(1<<0)
-
+//~~Vault 113~~
 var/const/CAPTAIN			=(1<<0)
-var/const/LEGRECRUIT		=(1<<1)
+var/const/HOP				=(1<<0)
+//var/const/RD				=(1<<0)
+//var/const/CMO				=(1<<3)
+
+//	Security
 var/const/WARDEN			=(1<<2)
 var/const/DETECTIVE			=(1<<3)
-
 var/const/OFFICER			=(1<<4)
-var/const/LEGDECAN			=(1<<5)
+var/const/ENGSEC			=(1<<0)
+
+//	Engineering ~ Robotics
 var/const/ENGINEER			=(1<<6)
-var/const/LEGVEX			=(1<<7)
-var/const/ROBOTICIST		=(1<<8)
 var/const/AI				=(1<<9)
+var/const/ROBOTICIST		=(1<<8)
 var/const/CYBORG			=(1<<10)
-var/const/LEGCENTURION		=(1<<11)
-var/const/LEGLEGAT			=(1<<12)
 
-var/const/MEDSCI			=(1<<1)
-
-//var/const/RD				=(1<<0)
+//	Research
 var/const/SCIENTIST			=(1<<1)
 var/const/CHEMIST			=(1<<2)
-//var/const/CMO				=(1<<3)
+var/const/MEDSCI			=(1<<1)
+
+//	Medical
 var/const/DOCTOR			=(1<<4)
 //var/const/GENETICIST		=(1<<5)
 //var/const/VIROLOGIST		=(1<<6)
 
-
+//	Civilian
 var/const/CIVILIAN			=(1<<2)
-
-var/const/HOP				=(1<<0)
 var/const/BARTENDER			=(1<<1)
 var/const/BOTANIST			=(1<<2)
 var/const/COOK				=(1<<3)
 var/const/JANITOR			=(1<<4)
-//var/const/LIBRARIAN			=(1<<5)
+//var/const/LIBRARIAN		=(1<<5)
 var/const/QUARTERMASTER		=(1<<6)
 var/const/CARGOTECH			=(1<<7)
 var/const/MINER				=(1<<8)
 //var/const/LAWYER			=(1<<9)
-//var/const/CHAPLAIN			=(1<<10)
-//var/const/CLOWN				=(1<<11)
-//var/const/MIME				=(1<<12)
+//var/const/CHAPLAIN		=(1<<10)
+//var/const/CLOWN			=(1<<11)
+//var/const/MIME			=(1<<12)
 var/const/ASSISTANT			=(1<<13)
+
+//~~Legion~~
+var/const/LEGRECRUIT		=(1<<1)
+var/const/LEGDECAN			=(1<<5)
+var/const/LEGVEX			=(1<<7)
+var/const/LEGCENTURION		=(1<<11)
+var/const/LEGLEGAT			=(1<<12)
+
+//~~Wasteland~~
 var/const/SCAVENGER         =(1<<14)
 var/const/REGULATOR         =(1<<15)
 var/const/SETTLER         	=(1<<16)
@@ -56,11 +63,6 @@ var/list/assistant_occupations = list(
 //	"Chaplain",
 //	"Lawyer",
 //	"Librarian",
-	"Regulator",
-	"Settler",
-	"Wastelandmedic",
-	"Raider",
-	"Scavenger"
 )
 
 
@@ -123,11 +125,6 @@ var/list/security_positions = list(
 //	"Head of Security",
 	"Warden",
 	"Detective",
-	"Legion Recruit",
-	"Legion Decan",
-	"Legion Vexillarius",
-	"Legion Centurion",
-	"Legion Legat",
 	"Security Officer"
 )
 
@@ -138,6 +135,21 @@ var/list/nonhuman_positions = list(
 	"pAI"
 )
 
+var/list/legion_positions = list(
+	"Legion Recruit",
+	"Legion Decan",
+	"Legion Vexillarius",
+	"Legion Centurion",
+	"Legion Legat",
+)
+
+var/list/wasteland_positions = list(
+	"Regulator",
+	"Settler",
+	"Wastelandmedic",
+	"Raider",
+	"Scavenger"
+)
 
 /proc/guest_jobbans(job)
 	return ((job in command_positions) || (job in nonhuman_positions) || (job in security_positions))


### PR DESCRIPTION
Sorted the job variables in the jobs.dm.  Also adjusted the manifest so
that it has a "~Vault Personnel~", "~Legion~", and "~Wasteland~"
sections. Personnel now sort into their correct sections on the
manifest.

This only adjusts the manifest that you access on the start screen, and as a ghost. The AI manifest is untouched.

(Better images to come soon)
![image](https://cloud.githubusercontent.com/assets/1237485/17964486/3ee60222-6a6e-11e6-8c32-2392cb86c74e.png)
All I could throw up in the bit of time available to me at the moment, I will attempt to get a better one up when I can.